### PR TITLE
Add targeting projectile casting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { Canvas, useFrame } from '@react-three/fiber'
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { Physics, RigidBody } from '@react-three/rapier'
 import {
   Gltf,
@@ -11,7 +11,9 @@ import {
 import Controller from 'ecctrl'
 import { useGameState } from './storage/game-state'
 import { models } from './consts/models'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
+import * as THREE from 'three'
+import Projectile from './Projectile'
 import characterSkillMap from './maps/character-skill-map.json'
 
 const mapKeys = (map, origin) => Object.entries(map).reduce((acc, [key, value]) => {
@@ -19,12 +21,14 @@ const mapKeys = (map, origin) => Object.entries(map).reduce((acc, [key, value]) 
   return {...acc, [key]: origin[value] }
 }, {})
 
-function AnimatedModel({ url, scale }) {
+function AnimatedModel({ url, scale, onCast }) {
   const { scene, animations } = useGLTF(url)
 
   const { actions: originActions, ref } = useAnimations(animations)
   const [actions, setActions] = useState({})
   const [subscribeKeys, getKeys] = useKeyboardControls();
+  const { camera, scene: threeScene } = useThree()
+  const castingRef = useRef(false)
 
   useEffect(() => {
     actions?.idle?.play()
@@ -38,18 +42,40 @@ function AnimatedModel({ url, scale }) {
     const { forward, backward, leftward, rightward, cast } = getKeys()
     const moving = forward || backward || leftward || rightward
 
-    if (cast && actions?.casting) {
-      if (!actions?.casting.isRunning()) {
+    if (cast) {
+      if (!castingRef.current) {
+        castingRef.current = true
+        if (onCast && ref.current) {
+          const pos = ref.current.getWorldPosition(new THREE.Vector3())
+          const raycaster = new THREE.Raycaster()
+          raycaster.setFromCamera(new THREE.Vector2(0, 0), camera)
+          const intersects = raycaster.intersectObjects(threeScene.children, true)
+          let target
+          if (intersects.length > 0) {
+            target = intersects[0].point
+          } else {
+            target = camera
+              .getWorldDirection(new THREE.Vector3())
+              .multiplyScalar(1000)
+              .add(camera.position)
+          }
+          const dir = target.clone().sub(pos).normalize()
+          onCast(pos, dir)
+        }
+      }
+      if (actions?.casting && !actions?.casting.isRunning()) {
         Object.values(actions).forEach((a) => a?.stop())
         actions?.casting.play()
       }
 
     } else if (moving && actions?.walk) {
+      castingRef.current = false
       if (!actions?.walk.isRunning()) {
         Object.values(actions).forEach((a) => a?.stop())
         actions?.walk.reset().play()
       }
     } else {
+      castingRef.current = false
       if (!actions?.idle?.isRunning()) {
         Object.values(actions).forEach((a) => a?.stop())
         actions?.idle?.play()
@@ -63,6 +89,11 @@ function AnimatedModel({ url, scale }) {
 export default function App() {
   const gameState = useGameState();
   const skinOptions = models[gameState.skin];
+  const [projectiles, setProjectiles] = useState([])
+
+  const handleCast = (pos, dir) => {
+    setProjectiles((p) => [...p, { id: Date.now() + Math.random(), pos, dir }])
+  }
 
   const keyboardMap = [
     { name: 'forward', keys: ['ArrowUp', 'KeyW'] },
@@ -85,9 +116,19 @@ export default function App() {
         <Physics timeStep="vary">
           <KeyboardControls map={keyboardMap}>
             <Controller maxVelLimit={5}>
-              <AnimatedModel url={skinOptions.path} scale={skinOptions.scale} />
+              <AnimatedModel url={skinOptions.path} scale={skinOptions.scale} onCast={handleCast} />
             </Controller>
           </KeyboardControls>
+          {projectiles.map((p) => (
+            <Projectile
+              key={p.id}
+              start={p.pos}
+              direction={p.dir}
+              onFinish={() =>
+                setProjectiles((s) => s.filter((pr) => pr.id !== p.id))
+              }
+            />
+          ))}
           <RigidBody type="fixed" colliders="trimesh">
             <Gltf castShadow receiveShadow scale={1} src="/models/zone-fantasy-2.glb" />
             {/*<Gltf castShadow receiveShadow rotation={[-Math.PI / 2, 0, 0]} scale={0.11} src="/fantasy_game_inn2-transformed.glb" />*/}

--- a/src/Projectile.js
+++ b/src/Projectile.js
@@ -1,0 +1,24 @@
+import { useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+
+export default function Projectile({ start, direction, onFinish }) {
+  const ref = useRef()
+  const startRef = useRef(start.clone())
+  const dirRef = useRef(direction.clone().normalize())
+
+  useFrame(() => {
+    if (!ref.current) return
+    ref.current.position.add(dirRef.current.clone().multiplyScalar(0.5))
+    if (ref.current.position.distanceTo(startRef.current) > 50) {
+      onFinish?.()
+    }
+  })
+
+  return (
+    <mesh ref={ref} position={startRef.current} castShadow>
+      <sphereGeometry args={[0.2, 8, 8]} />
+      <meshStandardMaterial color="orange" />
+    </mesh>
+  )
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,6 @@ createRoot(document.getElementById('root')).render(
   <>
     <App />
     <img className="controlKeys" src="/controls.png" alt="control keys" />
+    <div className="crosshair" />
   </>,
 )

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,3 +42,15 @@ body {
 .title > a {
   color: rgb(79, 189, 249);
 }
+
+.crosshair {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  transform: translate(-50%, -50%);
+  border: 2px solid rgba(255, 0, 0, 0.7);
+  border-radius: 50%;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- show crosshair in the middle of the screen
- create `Projectile` component for simple ability cast
- spawn projectiles from character when pressing `E`
- fire projectiles toward point under the crosshair

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fde67367c83298b09dfbd179d2f8e