### PR TITLE
Add third-person camera offset

### DIFF
--- a/src/CameraFollow.js
+++ b/src/CameraFollow.js
@@ -1,0 +1,23 @@
+import { useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { PerspectiveCamera } from '@react-three/drei'
+
+export default function CameraFollow({ target, offset = [1, 2, -4] }) {
+  const rig = useRef()
+  const camRef = useRef()
+
+  useFrame(() => {
+    if (!target?.current || !rig.current) return
+
+    rig.current.position.copy(target.current.position)
+    rig.current.quaternion.copy(target.current.quaternion)
+
+    camRef.current?.lookAt(target.current.position)
+  })
+
+  return (
+    <group ref={rig}>
+      <PerspectiveCamera ref={camRef} makeDefault position={offset} />
+    </group>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce `CameraFollow` component
- forward ref from `AnimatedModel`
- use the new camera rig in `App`
- refactor `CameraFollow` to use a React-style rig with `<PerspectiveCamera>`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdd57d2d48329ba5e5e9c37b572ee