### PR TITLE
Replace HeroUI Progress with custom component

### DIFF
--- a/src/components/game/layout/Interface.jsx
+++ b/src/components/game/layout/Interface.jsx
@@ -1,4 +1,4 @@
-import { Progress } from "@heroui/react";
+import { Progress } from "../../ui/Progress.jsx";
 import { useEffect, useState } from "react";
 import { useGameState } from '../../../storage/game-state.js'
 import { KeyboardHints } from "../parts/KeyboardHints.jsx";

--- a/src/components/game/parts/CastBar.jsx
+++ b/src/components/game/parts/CastBar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from "react";
-import { Progress } from "@heroui/react";
+import { Progress } from "../../ui/Progress.jsx";
 
 export const CastBar = () => {
     const [isCasting, setIsCasting] = useState(false);

--- a/src/components/game/parts/ExperienceBar.jsx
+++ b/src/components/game/parts/ExperienceBar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Progress } from "@heroui/react";
+import { Progress } from "../../ui/Progress.jsx";
 import { XP_PER_LEVEL } from "@/consts";
 
 export const ExperienceBar = () => {

--- a/src/components/ui/Progress.css
+++ b/src/components/ui/Progress.css
@@ -1,0 +1,24 @@
+.progress {
+  width: 100%;
+  height: 8px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0;
+}
+
+.progress-fill.primary {
+  background-color: #3490dc;
+}
+
+.progress-fill.secondary {
+  background-color: #6b7280;
+}
+
+.progress-fill.warning {
+  background-color: #f59e0b;
+}

--- a/src/components/ui/Progress.jsx
+++ b/src/components/ui/Progress.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Progress.css';
+
+export const Progress = ({ value = 0, color = 'primary', className = '', id, disableAnimation = false, ...props }) => {
+  const clamped = Math.max(0, Math.min(100, Number(value)));
+  const transition = disableAnimation ? 'none' : undefined;
+  return (
+    <div id={id} className={`progress ${className}`} {...props}>
+      <div
+        className={`progress-fill ${color}`}
+        style={{ width: `${clamped}%`, transition }}
+      />
+    </div>
+  );
+};
+
+Progress.propTypes = {
+  value: PropTypes.number,
+  color: PropTypes.string,
+  className: PropTypes.string,
+  id: PropTypes.string,
+  disableAnimation: PropTypes.bool,
+};


### PR DESCRIPTION
## Summary
- drop HeroUI `Progress` dependency and introduce a minimal native CSS implementation
- replace all `@heroui/react` progress imports with the new component

## Testing
- `npm run lint` *(fails: No files matching the pattern "my-app" were found)*

------
https://chatgpt.com/codex/tasks/task_e_6882470c40788329b16c2c55ebecdcdc