### PR TITLE
Replace useInterface with useGameState

### DIFF
--- a/src/components/game/parts/Buffs.jsx
+++ b/src/components/game/parts/Buffs.jsx
@@ -14,7 +14,7 @@ export const Buffs = (
     const getBuffs =  ({ buffs, debuffs }) => ({
         buffs, debuffs
     })
-    const {state: {buffs = [], debuffs = []}} = useGameState(getBuffs);
+    const { buffs = [], debuffs = [] } = useGameState(getBuffs);
     const [now, setNow] = useState(Date.now());
 
     const finalBuffs = propBuffs !== undefined ? propBuffs : buffs;

--- a/src/components/game/parts/Chat.jsx
+++ b/src/components/game/parts/Chat.jsx
@@ -2,15 +2,13 @@
 import { useState, useEffect } from "react";
 
 import "./Chat.css";
-import { useInterface } from "../../context/inteface";
+import { useGameState } from "../../../storage/game-state.js";
 import { useWS } from "../../hooks/useWS";
 
 export const Chat = () => {
   const [input, setInput] = useState("");
-  const {
-    state: { chatMessages: messages },
-    dispatch,
-  } = useInterface();
+  const messages = useGameState((s) => s.chatMessages);
+  const addChatMessage = useGameState((s) => s.addChatMessage);
   const { socket, sendToSocket } = useWS();
   const [userCount, setUserCount] = useState(0);
 
@@ -20,10 +18,7 @@ export const Chat = () => {
 
       switch (message.type) {
         case "SEND_CHAT_MESSAGE":
-          dispatch({
-            type: "SEND_CHAT_MESSAGE",
-            payload: `${message?.character?.name ?? "Anon"} say: ${message.payload}`,
-          });
+          addChatMessage(`${message?.character?.name ?? "Anon"} say: ${message.payload}`);
           break;
         case "CHAT_USER_COUNT":
           setUserCount(message.count);
@@ -40,7 +35,7 @@ export const Chat = () => {
 
   const handleSend = () => {
     if (input.trim() !== "") {
-      dispatch({ type: "SEND_CHAT_MESSAGE", payload: `Me: ${input}` });
+      addChatMessage(`Me: ${input}`);
       sendToSocket({ type: "SEND_CHAT_MESSAGE", payload: input });
       setInput("");
     }

--- a/src/components/game/parts/ComboPoints.jsx
+++ b/src/components/game/parts/ComboPoints.jsx
@@ -1,10 +1,11 @@
-import { useInterface } from '@/context/inteface';
+import { useGameState } from '../../../storage/game-state.js';
 import Image from 'next/image';
 import { assetUrl } from '../../utilities/assets';
 import './ComboPoints.css';
 
 export const ComboPoints = () => {
-    const { state: { buffs = [], character } } = useInterface();
+    const buffs = useGameState((s) => s.buffs);
+    const character = useGameState((s) => s.character);
     if (!character || character.name !== 'rogue') return null;
     const combo = buffs.find(b => b.type === 'combo');
     const count = combo?.stacks || 0;

--- a/src/components/game/parts/Menu.jsx
+++ b/src/components/game/parts/Menu.jsx
@@ -1,15 +1,16 @@
-import { useInterface } from "../../context/inteface";
+import { useGameState } from "../../../storage/game-state.js";
 import { useRouter } from "next/navigation";
 import { ButtonWithSound as Button } from "../button-with-sound";
 import "./Menu.css";
 
 export const GameMenu = () => {
-    const { state: { menuVisible }, dispatch } = useInterface();
+    const menuVisible = useGameState((s) => s.menuVisible);
+    const setMenuVisible = useGameState((s) => s.setMenuVisible);
     const router = useRouter();
 
     if (!menuVisible) return null;
 
-    const closeMenu = () => dispatch({ type: 'SET_MENU_VISIBLE', payload: false });
+    const closeMenu = () => setMenuVisible(false);
 
     return (
         <div className="menu-overlay flex flex-col gap-2">

--- a/src/components/game/parts/Scoreboard.jsx
+++ b/src/components/game/parts/Scoreboard.jsx
@@ -1,8 +1,9 @@
-import {useInterface} from "../../context/inteface";
+import {useGameState} from "../../../storage/game-state.js";
 import './Scoreboard.css';
 
 export const Scoreboard = () => {
-    const {state: {scoreboardVisible, scoreboardData}} = useInterface();
+    const scoreboardVisible = useGameState((s) => s.scoreboardVisible);
+    const scoreboardData = useGameState((s) => s.scoreboardData);
 
     if (!scoreboardVisible) return null;
 

--- a/src/components/game/parts/SkillBar.jsx
+++ b/src/components/game/parts/SkillBar.jsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
-import {useInterface} from '@/context/inteface';
+import {useGameState} from '../../../storage/game-state.js';
 import {useWS} from '../../hooks/useWS';
 import { SPELL_COST } from '@/consts';
 import './SkillBar.css';
@@ -45,7 +45,7 @@ const WARRIOR_SKILLS = [
 ];
 
 export const SkillBar = ({ mana = 0, level = 1, skillPoints = 0, learnedSkills = {} }) => {
-    const {state: {character}} = useInterface();
+    const character = useGameState((s) => s.character);
     let skills = DEFAULT_SKILLS;
     if (character?.name === 'warlock') skills = WARLOCK_SKILLS;
     else if (character?.name === 'paladin') skills = PALADIN_SKILLS;

--- a/src/components/game/parts/StatsModal.jsx
+++ b/src/components/game/parts/StatsModal.jsx
@@ -1,9 +1,11 @@
-import { useInterface } from "../../context/inteface";
+import { useGameState } from "../../../storage/game-state.js";
 import { useEffect, useState } from "react";
 import { Modal } from "../modal";
 
 export const StatsModal = () => {
-    const { state: { statsVisible, character }, dispatch } = useInterface();
+    const statsVisible = useGameState((s) => s.statsVisible);
+    const character = useGameState((s) => s.character);
+    const setStatsVisible = useGameState((s) => s.setStatsVisible);
     const [stats, setStats] = useState({hp:0, armor:0, maxHp:0, maxArmor:0});
 
     useEffect(() => {
@@ -25,7 +27,7 @@ export const StatsModal = () => {
         <Modal
             open={statsVisible}
             title={`${character?.classType || ''} stats`}
-            onChange={(open) => dispatch({ type: 'SET_STATS_VISIBLE', payload: open })}
+            onChange={(open) => setStatsVisible(open)}
             size="sm"
             actions={[]}
         >

--- a/src/storage/game-state.js
+++ b/src/storage/game-state.js
@@ -1,4 +1,3 @@
-
 import { create } from 'zustand'
 
 export const useGameState = create((set) => ({
@@ -13,4 +12,14 @@ export const useGameState = create((set) => ({
   buffs: [],
   debuffs: [],
   players: [],
+  setStatsVisible: (visible) => set({ statsVisible: visible }),
+  setMenuVisible: (visible) => set({ menuVisible: visible }),
+  addChatMessage: (text) => set((state) => ({
+    chatMessages: [...state.chatMessages, { text, id: Date.now() }],
+  })),
+  setCharacter: (character) => set({ character }),
+  setBuffs: (buffs) => set({ buffs }),
+  setDebuffs: (debuffs) => set({ debuffs }),
+  setScoreboardData: (data) => set({ scoreboardData: data }),
+  setScoreboardVisible: (visible) => set({ scoreboardVisible: visible }),
 }))


### PR DESCRIPTION
## Summary
- swap out `useInterface` hooks for `useGameState`
- extend `useGameState` with mutator helpers
- update game parts to use new store functions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: No files matching the pattern)*

------
https://chatgpt.com/codex/tasks/task_e_68824ae3ff3083299227506a1a7033ae