### PR TITLE
Update skill icon paths

### DIFF
--- a/src/skills/mage/blink.js
+++ b/src/skills/mage/blink.js
@@ -1,4 +1,3 @@
-import { assetUrl } from '../../utilities/assets';
 import * as THREE from 'three';
 import { Capsule } from 'three/examples/jsm/math/Capsule';
 import { SPELL_COST } from '../../consts';
@@ -6,7 +5,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'blink',
   key: 'F',
-  icon: assetUrl('/icons/classes/mage/blink.jpg'),
+  icon: '/images/icons/classes/mage/blink.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/mage/fireBarrier.js
+++ b/src/skills/mage/fireBarrier.js
@@ -1,4 +1,3 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {

--- a/src/skills/mage/fireRing.js
+++ b/src/skills/mage/fireRing.js
@@ -1,5 +1,4 @@
 import { SPELL_COST } from "../../consts";
-import { assetUrl } from "../../utilities/assets";
 
 export const meta = {
   id: "firering",

--- a/src/skills/mage/fireball.js
+++ b/src/skills/mage/fireball.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'fireball',
   key: 'E',
-  icon: assetUrl('/icons/classes/mage/fireball.png'),
+  icon: '/images/icons/classes/mage/fireball.png',
   autoFocus: false,
 };
 

--- a/src/skills/paladin/divineSpeed.js
+++ b/src/skills/paladin/divineSpeed.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'divine-speed',
   key: 'F',
-  icon: assetUrl('/icons/classes/paladin/speedoflight.jpg'),
+  icon: '/images/icons/classes/paladin/speedoflight.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/paladin/heal.js
+++ b/src/skills/paladin/heal.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'paladin-heal',
   key: 'Q',
-  icon: assetUrl('/icons/classes/paladin/searinglight.jpg'),
+  icon: '/images/icons/classes/paladin/searinglight.jpg',
   autoFocus: false,
 
 

--- a/src/skills/paladin/lightStrike.js
+++ b/src/skills/paladin/lightStrike.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'lightstrike',
   key: 'E',
-  icon: assetUrl('/icons/classes/paladin/crusaderstrike.jpg'),
+  icon: '/images/icons/classes/paladin/crusaderstrike.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/paladin/stun.js
+++ b/src/skills/paladin/stun.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'stun',
   key: 'R',
-  icon: assetUrl('/icons/classes/paladin/sealofmight.jpg'),
+  icon: '/images/icons/classes/paladin/sealofmight.jpg',
 };
 
 export default function castStun({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {

--- a/src/skills/rogue/bloodStrike.js
+++ b/src/skills/rogue/bloodStrike.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'blood-strike',
   key: 'E',
-  icon: assetUrl('/icons/classes/rogue/sinister_strike.jpg'),
+  icon: '/images/icons/classes/rogue/sinister_strike.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/rogue/eviscerate.js
+++ b/src/skills/rogue/eviscerate.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'eviscerate',
   key: 'R',
-  icon: assetUrl('/icons/classes/rogue/eviscerate.jpg'),
+  icon: '/images/icons/classes/rogue/eviscerate.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/rogue/kidneyStrike.js
+++ b/src/skills/rogue/kidneyStrike.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'kidney-strike',
   key: 'F',
-  icon: assetUrl('/icons/classes/rogue/kidneyshot.jpg'),
+  icon: '/images/icons/classes/rogue/kidneyshot.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/rogue/sprint.js
+++ b/src/skills/rogue/sprint.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'sprint',
   key: 'Q',
-  icon: assetUrl('/icons/classes/rogue/sprint.jpg'),
+  icon: '/images/icons/classes/rogue/sprint.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/warlock/corruption.js
+++ b/src/skills/warlock/corruption.js
@@ -1,7 +1,6 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
-export const meta = { id: 'corruption', key: 'R', icon: assetUrl('/icons/classes/warlock/spell_corruption.jpg') };
+export const meta = { id: 'corruption', key: 'R', icon: '/images/icons/classes/warlock/spell_corruption.jpg' };
 
 export default function castCorruption({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {
   if (globalSkillCooldown || isCasting) return;

--- a/src/skills/warlock/lifeDrain.js
+++ b/src/skills/warlock/lifeDrain.js
@@ -1,7 +1,6 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
-export const meta = { id: 'lifedrain', key: 'F', icon: assetUrl('/icons/classes/warlock/lifedrain.jpg') };
+export const meta = { id: 'lifedrain', key: 'F', icon: '/images/icons/classes/warlock/lifedrain.jpg' };
 
 export default function castLifeDrain({
   playerId,

--- a/src/skills/warlock/lifeTap.js
+++ b/src/skills/warlock/lifeTap.js
@@ -1,7 +1,6 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
-export const meta = { id: 'lifetap', key: 'Q', icon: assetUrl('/icons/classes/warlock/spell_shadow_burningspirit.jpg') };
+export const meta = { id: 'lifetap', key: 'Q', icon: '/images/icons/classes/warlock/spell_shadow_burningspirit.jpg' };
 
 export default function castLifeTap({
   playerId,

--- a/src/skills/warlock/shadowbolt.js
+++ b/src/skills/warlock/shadowbolt.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import castProjectile from '../common/castProjectile';
 
 export const meta = {
   id: 'shadowbolt',
   key: 'E',
-  icon: assetUrl('/icons/classes/warlock/spell_shadowbolt.jpg'),
+  icon: '/images/icons/classes/warlock/spell_shadowbolt.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/warrior/bladestorm.js
+++ b/src/skills/warrior/bladestorm.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'bladestorm',
   key: 'Q',
-  icon: assetUrl('/icons/classes/warrior/bladestorm.jpg'),
+  icon: '/images/icons/classes/warrior/bladestorm.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/warrior/hook.js
+++ b/src/skills/warrior/hook.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'hook',
   key: 'F',
-  icon: assetUrl('/icons/classes/warrior/hamstring.jpg'),
+  icon: '/images/icons/classes/warrior/hamstring.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/warrior/savageBlow.js
+++ b/src/skills/warrior/savageBlow.js
@@ -1,10 +1,9 @@
-import { assetUrl } from '../../utilities/assets';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
   id: 'savage-blow',
   key: 'E',
-  icon: assetUrl('/icons/classes/warrior/savageblow.jpg'),
+  icon: '/images/icons/classes/warrior/savageblow.jpg',
   autoFocus: false,
 };
 

--- a/src/skills/warrior/warbringer.js
+++ b/src/skills/warrior/warbringer.js
@@ -1,4 +1,3 @@
-import { assetUrl } from '../../utilities/assets';
 import * as THREE from 'three';
 import { Capsule } from 'three/examples/jsm/math/Capsule';
 import { SPELL_COST } from '../../consts';
@@ -6,7 +5,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'warbringer',
   key: 'R',
-  icon: assetUrl('/icons/classes/warrior/warbringer.jpg'),
+  icon: '/images/icons/classes/warrior/warbringer.jpg',
   autoFocus: false,
 };
 


### PR DESCRIPTION
## Summary
- remove `assetUrl` usages from skill modules
- reference images directly from `/images/icons`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884c38c1e848329b8ae13bfa2ac4863