### PR TITLE
Add play and matches routes

### DIFF
--- a/src/components/game/game.jsx
+++ b/src/components/game/game.jsx
@@ -27,7 +27,7 @@ function ResetOnFall({ playerRef, threshold = -5, resetPosition = [0, 2, 0] }) {
 }
 
 
-export function Game() {
+export function Game({ matchId = null }) {
   const gameState = useGameState()
   const skinOptions = models[gameState.skin]
   const [projectiles, setProjectiles] = useState([])

--- a/src/components/matches/MatchDetails.jsx
+++ b/src/components/matches/MatchDetails.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link, useNavigate } from 'react-router'
+import { useWS } from '../../hooks/useWS'
+
+export const MatchDetails = () => {
+  const { matchId } = useParams()
+  const navigate = useNavigate()
+  const { socket, sendToSocket } = useWS(matchId)
+  const [match, setMatch] = useState(null)
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      let message
+      try {
+        message = JSON.parse(event.data)
+      } catch {
+        return
+      }
+      if (message.type === 'GET_MATCH' && message.match?.id === matchId) {
+        setMatch(message.match)
+      }
+    }
+
+    socket.addEventListener('message', handleMessage)
+    sendToSocket({ type: 'GET_MATCH', matchId })
+
+    return () => socket.removeEventListener('message', handleMessage)
+  }, [matchId])
+
+  if (!match) return <div className="p-4">Loading...</div>
+
+  const handleJoin = () => {
+    navigate(`/play/${matchId}`)
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="text-xl">Match {match.name || match.id}</h2>
+      <div>Players: {(match.players?.length || 0)}/{match.maxPlayers}</div>
+      <button className="px-2 py-1 bg-blue-600 text-white rounded" onClick={handleJoin}>
+        Join
+      </button>
+      <div>
+        <Link to="/matches">Back to list</Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/matches/MatchesList.jsx
+++ b/src/components/matches/MatchesList.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router'
+import { useWS } from '../../hooks/useWS'
+
+export const MatchesList = () => {
+  const { socket, sendToSocket } = useWS()
+  const [matches, setMatches] = useState([])
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      let message
+      try {
+        message = JSON.parse(event.data)
+      } catch {
+        return
+      }
+      if (message.type === 'MATCH_LIST') {
+        setMatches(message.matches || [])
+      }
+    }
+
+    socket.addEventListener('message', handleMessage)
+    sendToSocket({ type: 'GET_MATCHES' })
+
+    return () => socket.removeEventListener('message', handleMessage)
+  }, [])
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-2">Matches</h1>
+      <ul className="space-y-2">
+        {matches.map((m) => (
+          <li key={m.id} className="border p-2 rounded">
+            <Link to={`/matches/${m.id}`}>{m.name || m.id}</Link>
+            <span className="ml-2 text-sm text-gray-400">
+              {(m.players?.length || 0)}/{m.maxPlayers}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/navigation/navigation.jsx
+++ b/src/components/navigation/navigation.jsx
@@ -3,6 +3,8 @@ import { TabNav } from '@radix-ui/themes'
 export const Navigation = () => {
   return (
     <TabNav.Root  justify="center" color="gold" className="h-[98px] bg-black">
+      <TabNav.Link href="/play">Play</TabNav.Link>
+      <TabNav.Link href="/matches">Matches</TabNav.Link>
       <TabNav.Link href="#" active>
         Account
       </TabNav.Link>

--- a/src/hooks/useWS.js
+++ b/src/hooks/useWS.js
@@ -9,11 +9,13 @@ const socket = new WebSocket(`ws://${SOCKET_URL}`);
 export const useWS = (matchId = null) => {
   const account = useCurrentAccount();
   const address = account?.address;
-  const character = useGameState(s => s.character);
+  const character = useGameState((s) => s.character);
+  const joinedMatch = useGameState((s) => s.joinedMatch);
 
   const sendToSocket = (data) => {
     if (!socket || socket.readyState !== WebSocket.OPEN) return;
-    socket.send(JSON.stringify({ address, matchId, character, ...data }));
+    const id = matchId ?? joinedMatch ?? null;
+    socket.send(JSON.stringify({ address, matchId: id, character, ...data }));
   };
 
   return { socket, sendToSocket };

--- a/src/routes/game.jsx
+++ b/src/routes/game.jsx
@@ -1,11 +1,21 @@
 import { Game } from '../components/game/game.jsx'
 import { Interface } from '../components/game/interface/Interface'
+import { useParams } from 'react-router'
+import { useEffect } from 'react'
+import { useGameState } from '../storage/game-state.js'
 
 
 export function GameRoute() {
+  const { matchId } = useParams()
+  const setJoinedMatch = useGameState((s) => s.setJoinedMatch)
+
+  useEffect(() => {
+    setJoinedMatch(matchId || null)
+  }, [matchId, setJoinedMatch])
+
   return (
     <>
-      <Game />
+      <Game matchId={matchId} />
       <img className="controlKeys" src="/controls.png" alt="control keys" />
       <div className="crosshair" />
       <Interface />

--- a/src/routes/matches.jsx
+++ b/src/routes/matches.jsx
@@ -1,0 +1,10 @@
+import { MatchesList } from '../components/matches/MatchesList.jsx'
+import { MatchDetails } from '../components/matches/MatchDetails.jsx'
+
+export function MatchesRoute() {
+  return <MatchesList />
+}
+
+export function MatchRoute() {
+  return <MatchDetails />
+}

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router'
 import { GameRoute } from './game.jsx'
 import { MainRoute } from './main.jsx'
+import { MatchesRoute, MatchRoute } from './matches.jsx'
 
 export const router = createBrowserRouter([
   {
@@ -10,5 +11,17 @@ export const router = createBrowserRouter([
   {
     path: '/play',
     element: <GameRoute />,
+  },
+  {
+    path: '/play/:matchId',
+    element: <GameRoute />,
+  },
+  {
+    path: '/matches',
+    element: <MatchesRoute />,
+  },
+  {
+    path: '/matches/:matchId',
+    element: <MatchRoute />,
   },
 ])

--- a/src/storage/game-state.js
+++ b/src/storage/game-state.js
@@ -24,4 +24,5 @@ export const useGameState = create((set) => ({
   setDebuffs: (debuffs) => set({ debuffs }),
   setScoreboardData: (data) => set({ scoreboardData: data }),
   setScoreboardVisible: (visible) => set({ scoreboardVisible: visible }),
+  setJoinedMatch: (matchId) => set({ joinedMatch: matchId }),
 }))


### PR DESCRIPTION
## Summary
- implement new `/matches` route with match details
- handle optional `/play/:matchId` route
- wire up navigation links to Play and Matches
- add joinedMatch state and pass matchId to websocket calls

## Testing
- `npm run lint` *(fails: No files matching the pattern "my-app" were found)*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884c3c6a6448329bda9cf678978cd6f