### PR TITLE
Implement match creation form

### DIFF
--- a/src/components/matches/MatchCreateForm.jsx
+++ b/src/components/matches/MatchCreateForm.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { Button, Flex, TextField, Text } from '@radix-ui/themes';
+import { useWS } from '../../hooks/useWS';
+
+export const MatchCreateForm = () => {
+  const { sendToSocket } = useWS();
+  const [name, setName] = useState('');
+  const [maxPlayers, setMaxPlayers] = useState(6);
+
+  const handleCreate = () => {
+    const max = Number(maxPlayers) || 6;
+    sendToSocket({ type: 'CREATE_MATCH', name: name.trim(), maxPlayers: max });
+    setName('');
+    setMaxPlayers(6);
+  };
+
+  return (
+    <Flex gap="2" align="end" className="mb-4" wrap="wrap">
+      <Flex direction="column">
+        <Text as="label" size="2">Name</Text>
+        <TextField.Root>
+          <TextField.Input value={name} onChange={(e) => setName(e.target.value)} />
+        </TextField.Root>
+      </Flex>
+      <Flex direction="column">
+        <Text as="label" size="2">Max players</Text>
+        <TextField.Root>
+          <TextField.Input
+            type="number"
+            min="1"
+            max="16"
+            value={maxPlayers}
+            onChange={(e) => setMaxPlayers(e.target.value)}
+          />
+        </TextField.Root>
+      </Flex>
+      <Button onClick={handleCreate}>Create</Button>
+    </Flex>
+  );
+};

--- a/src/components/matches/MatchesList.jsx
+++ b/src/components/matches/MatchesList.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 import { useWS } from '../../hooks/useWS'
+import { MatchCreateForm } from './MatchCreateForm.jsx'
+import { Card, Flex, Heading, Text } from '@radix-ui/themes'
 
 export const MatchesList = () => {
   const { socket, sendToSocket } = useWS()
@@ -26,18 +28,27 @@ export const MatchesList = () => {
   }, [])
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl mb-2">Matches</h1>
-      <ul className="space-y-2">
-        {matches.map((m) => (
-          <li key={m.id} className="border p-2 rounded">
-            <Link to={`/matches/${m.id}`}>{m.name || m.id}</Link>
-            <span className="ml-2 text-sm text-gray-400">
-              {(m.players?.length || 0)}/{m.maxPlayers}
-            </span>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Flex direction="column" p="4">
+      <Heading size="4" mb="2">
+        Matches
+      </Heading>
+      <MatchCreateForm />
+      <Flex direction="column" gap="2" asChild>
+        <ul>
+          {matches.map((m) => (
+            <Card key={m.id} asChild>
+              <li className="list-none">
+                <Flex justify="between" align="center">
+                  <Link to={`/matches/${m.id}`}>{m.name || m.id}</Link>
+                  <Text color="gray" size="2">
+                    {(m.players?.length || 0)}/{m.maxPlayers}
+                  </Text>
+                </Flex>
+              </li>
+            </Card>
+          ))}
+        </ul>
+      </Flex>
+    </Flex>
   )
 }


### PR DESCRIPTION
## Summary
- add a new `MatchCreateForm` using Radix components
- embed match creation form in matches list
- style matches list with Radix components

## Testing
- `npm run lint` *(fails: No files matching the pattern)*
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6884ce9f49ac8329b8891fe24668d247